### PR TITLE
bugfix: Fixed `surface` field is nil when sorting table `filtered_trains` in `script/dispatcher.lua`.

### DIFF
--- a/script/dispatcher.lua
+++ b/script/dispatcher.lua
@@ -389,6 +389,7 @@ local function getFreeTrains(nextStop, min_carriages, max_carriages, type, size)
                     local distance = getStationDistance(trainData.train.station, nextStop.stop.entity)
                     table.insert(filtered_trains, {
                         train = trainData.train,
+                        surface = trainData.surface,
                         inventory_size = inventorySize,
                         depot_priority = trainData.depot_priority,
                         provider_distance = distance,


### PR DESCRIPTION
In the case where the train and the next stop are on the same surface, the value structure inserted into filtered_trains is 
```-- train is on the same surface as the next stop 
{ 
    train = trainData.train, 
    inventory_size = inventorySize, 
    depot_priority = trainData.depot_priority, 
    provider_distance = distance, 
} 
```

When sorting all trains to find the best matching train with code 

```
table.sort(filtered_trains, function(a, b) 
    -- if A is on the same surface as the stop and B is not, return true 
    if a.surface.index == stop_surface_index and b.surface.index ~= stop_surface_index then 
        return true 
    -- if B is on the same surface as the stop and A is not, return false 
    elseif ...
```

This code will call the `surface` field of each value. However, in the case where the train and the next stop are on the same surface, the value does not have a `surface` field, resulting in the error "attempt to index field 'surface' (a nil value)". After testing, adding a surface field to the above instance, the mod resumed normal scheduling.