### PR TITLE
Add per-player setting to silence LTN console messages

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -27,6 +27,14 @@ Selects the level of messages sent to the game console:
 - `2` - Notifications for deliveries
 - `3` - Detailed messages
 
+## Console messages (ltn-interface-console-messages) - boolean, default is true
+
+If `true`, LTN console messages (deliveries, warnings, errors) are shown in chat for this player.
+
+If `false`, those messages are silenced for this player only. Useful in multiplayer when the chat spam and notification sounds are distracting.
+
+This setting is per-player. The map-wide Message Level still controls which messages are generated for players who keep console messages enabled.
+
 ## GPS Tags (ltn-interface-message-gps) - boolean, default is false
 
 Console messages contain [Factorio rich text](https://wiki.factorio.com/rich_text) GPS tags which can be clicked.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 Version: 3.0.2
 Date: ????
   Changes:
+    - Added per-player setting "Console messages" to silence LTN chat notifications without affecting other players.
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.1
 Date: 2026-07-30

--- a/locale/de/settings.cfg
+++ b/locale/de/settings.cfg
@@ -1,5 +1,6 @@
 [mod-setting-name]
 ltn-interface-console-level=Nachrichtendetailgrad
+ltn-interface-console-messages=Konsolennachrichten
 ltn-interface-factorio-alerts=Factorio Alarme
 ltn-interface-debug-logfile=Debug-Protokollierung aktivieren
 ltn-dispatcher-enabled=Disponent aktiv
@@ -28,6 +29,7 @@ ltn-depot-stop-limit-trains=Zugbeschränkungen für LTN Haltestellen
 
 [mod-setting-description]
 ltn-interface-console-level=Nachrichten Detailgrad.\n\n0: Aus\nKeine Nachrichten werden generiert.\n\n1: Fehler & Warnungen\nNur Fehler & Warnungen werden generiert.\n\n2: Informationen (Standardwert)\nInformiert über grundlegende Informationen wie fehlende Ressourcen und erstellte Lieferungen.\n\n3: Ausführliche Nachrichten\nErweiterte Informationen über Stations- und Zug-Suche.
+ltn-interface-console-messages=LTN-Nachrichten in der Konsolen-Chat anzeigen. Deaktivieren, um Lieferbenachrichtigungen und Warnungen nur für diesen Spieler stummzuschalten (nützlich im Mehrspielermodus).
 ltn-interface-factorio-alerts=Fehler & Warnungen werden als Factorio Alarme angezeigt.
 ltn-interface-debug-logfile=Schreibt Debug Informationen in /Factorio/factorio-current.log.
 

--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -1,5 +1,6 @@
 [mod-setting-name]
 ltn-interface-console-level=Message level
+ltn-interface-console-messages=Console messages
 ltn-interface-message-gps=GPS tags
 ltn-interface-factorio-alerts=Factorio Alerts
 ltn-interface-debug-logfile=Enable debug log
@@ -29,6 +30,7 @@ ltn-depot-stop-limit-trains=Limit Trains on LTN depot stops
 
 [mod-setting-description]
 ltn-interface-console-level=Detail level of in game messages.\n\n0: Off\nNo messages will be generated.\n\n1: Errors & Warnings\nPrint only errors and warnings.\n\n2: Notifications (default)\nPrint basic information like missing resources or generating deliveries.\n\n3: Detailed Messages\nPrint detailed information about finding providers and trains.
+ltn-interface-console-messages=Show LTN messages in the console chat. Disable to silence delivery notifications and warnings for this player only (useful in multiplayer).
 ltn-interface-factorio-alerts=Show errors and warnings as Factorio alerts
 ltn-interface-debug-logfile=Write debug information to /Factorio/factorio-current.log.
 ltn-dispatcher-enabled=Warning: Deactivating Dispatcher stops delivery generation.\nItem levels will still be monitored.

--- a/script/tools.lua
+++ b/script/tools.lua
@@ -57,24 +57,26 @@ end
 -----------------------------------------------------------------------
 
 ---@type PrintSettings
-local settings = {
+local print_settings = {
     sound = defines.print_sound.use_player_settings,
     skip = defines.print_skip.if_visible,
 }
 
 ---@alias msg_func fun():LocalisedString
 
---- write msg to console for all member of force or all players
+--- write msg to console for all members of force or all players who have console messages enabled
 ---@param level number
 ---@param msg_func msg_func
 ---@param force LuaForce?
 function Tools.printmsg(level, msg_func, force)
     if LtnSettings and ((not LtnSettings.message_level) or (LtnSettings.message_level < level)) then return end
 
-    if force and force.valid then
-        force.print(msg_func(), settings)
-    else
-        game.print(msg_func(), settings)
+    local players = (force and force.valid) and force.players or game.players
+    local msg = msg_func()
+    for _, player in pairs(players) do
+        if player.valid and settings.get_player_settings(player)['ltn-interface-console-messages'].value then
+            player.print(msg, print_settings)
+        end
     end
 end
 

--- a/settings.lua
+++ b/settings.lua
@@ -40,6 +40,13 @@ data:extend {
     },
     {
         type = 'bool-setting',
+        name = 'ltn-interface-console-messages',
+        order = 'ae',
+        setting_type = 'runtime-per-user',
+        default_value = true
+    },
+    {
+        type = 'bool-setting',
         name = 'ltn-interface-message-gps',
         order = 'af',
         setting_type = 'runtime-global',


### PR DESCRIPTION
## Summary
- Adds a per-player **Console messages** setting (`ltn-interface-console-messages`, default on) so players can silence LTN chat notifications without affecting others
- Updates `Tools.printmsg` to print only to players who have console messages enabled
- Documents the setting in SETTINGS.md and en/de locales

## Test plan
- [ ] Load the mod in a multiplayer (or local) game
- [ ] Confirm LTN delivery/warning messages still appear with the setting enabled (default)
- [ ] Disable **Console messages** under Per player mod settings and confirm chat notifications stop for that player
- [ ] Confirm other players still receive messages when one player has muted them
- [ ] Confirm existing **Factorio Alerts** per-player toggle still works independently
